### PR TITLE
Now works with BOINC 7.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#Ignore build directory
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message (status "BOINC FOUND: ${BOINC_SERVER_FOUND}, MYSQL FOUND: ${MYSQL_FOUND}
 
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_library(undvc_common vector_io arguments file_io parse_xml)
+add_library(undvc_common vector_io.cxx arguments.cxx file_io.cxx parse_xml.cxx)
 
 message(status "BOOST LIBRARIES: ${Boost_LIBRARIES}")
 

--- a/cmake/Modules/FindBOINC.cmake
+++ b/cmake/Modules/FindBOINC.cmake
@@ -16,34 +16,37 @@ FIND_PATH(BOINC_INCLUDE_DIR api/boinc_api.h
     /boinc/src/boinc
     /home/tdesell/boinc
     /Users/deselt/Software/boinc
+    /boinc/WorkunitBundlingDev/boinc
     $ENV{BOINC_SOURCE}
 )
 MESSAGE(STATUS "BOINC include directory: ${BOINC_INCLUDE_DIR}")
 
+MESSAGE(STATUS "BOINC source: $ENV{BOINC_SOURCE}")
+
 FIND_LIBRARY(BOINC_LIBRARY
     NAMES boinc
-    PATHS /boinc/src/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ $ENV{BOINC_SOURCE}
+    PATHS /boinc/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ /boinc/WorkunitBundlingDev/boinc/ $ENV{BOINC_SOURCE}
     PATH_SUFFIXES lib
 )
 MESSAGE(STATUS "BOINC library: ${BOINC_LIBRARY}")
 
 FIND_LIBRARY(BOINC_CRYPT_LIBRARY
     NAMES boinc_crypt
-    PATHS /boinc/src/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ $ENV{BOINC_SOURCE}
+    PATHS /boinc/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ /boinc/WorkunitBundlingDev/boinc/ $ENV{BOINC_SOURCE}
     PATH_SUFFIXES lib
 )
 MESSAGE(STATUS "BOINC crypt library: ${BOINC_CRYPT_LIBRARY}")
 
 FIND_LIBRARY(BOINC_API_LIBRARY
     NAMES boinc_api
-    PATHS /boinc/src/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ $ENV{BOINC_SOURCE}
+    PATHS /boinc/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ /boinc/WorkunitBundlingDev/boinc/ $ENV{BOINC_SOURCE}
     PATH_SUFFIXES api
 )
 MESSAGE(STATUS "BOINC api library: ${BOINC_API_LIBRARY}")
 
 FIND_LIBRARY(BOINC_SCHED_LIBRARY
     NAMES sched
-    PATHS /boinc/src/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ $ENV{BOINC_SOURCE}
+    PATHS /boinc/boinc /home/tdesell/boinc /Users/deselt/Software/boinc/mac_build/build/Deployment/ /boinc/WorkunitBundlingDev/boinc/ $ENV{BOINC_SOURCE}
     PATH_SUFFIXES sched
 )
 MESSAGE(STATUS "BOINC sched library: ${BOINC_SCHED_LIBRARY}")

--- a/parse_xml.cxx
+++ b/parse_xml.cxx
@@ -101,3 +101,5 @@ void parse_xml_vector(string xml, const char tag[], vector<T> &result) throw (st
 
 template void parse_xml_vector<double>(string xml, const char tag[], vector<double> &result) throw (string);
 template void parse_xml_vector<uint64_t>(string xml, const char tag[], vector<uint64_t> &result) throw (string);
+template void parse_xml_vector<uint32_t>(string xml, const char tag[], vector<uint32_t> &result) throw (string);
+template void parse_xml_vector<int>(string xml, const char tag[], vector<int> &result) throw (string);

--- a/vector_io.cxx
+++ b/vector_io.cxx
@@ -125,4 +125,5 @@ template string vector_2d_to_string(const vector< vector<double> > &v);
 
 template void string_to_vector<double>(string s, vector<double> &v);
 template void string_to_vector<uint64_t>(string s, vector<uint64_t> &v);
-
+template void string_to_vector<int>(string s, vector<int> &v);
+template void string_to_vector<uint32_t>(string s, vector<uint32_t> &v);


### PR DESCRIPTION
- in cmake/Modules/FindBOINC.cmake: added file path for milkyway_new to be able to find boinc directory in WorkunitBundlingDev
- in CMakeLists.txt: added file types in add_library to get rid of warning
- explicit instantiation of templates for int and uint32_t for string_to_vector in vector_io.cxx and parse_xml_vector in parse_xml.cxx  